### PR TITLE
Add docs on how to add new modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NEBULA-docs
 With the [NEBULA framework](https://github.com/esciencecenter-digital-skills/NEBULA), you can create an easily maintainable, version-controllable, web-based lesson collection. This repository provides general guidelines on how to create your custom-made lesson, including how to add new modules to it.
 
+- [Creating a content repository](content-repo-instantiation.md)
 - [Elements of a module](module-elements.md)
 - [Module directory structure and content tags](module-dir-structure.md)
 - [Serving the site locally](local-rendering.md)

--- a/content-repo-instantiation.md
+++ b/content-repo-instantiation.md
@@ -1,0 +1,3 @@
+# Creating a content repository
+
+If you are starting a lesson from scratch, you can create an initial template repository using [NEBULA-content-template](https://github.com/esciencecenter-digital-skills/NEBULA-content-template). There, you can find more instructions on how to set up your template repo.

--- a/module-dir-structure.md
+++ b/module-dir-structure.md
@@ -15,14 +15,14 @@ my-new-module
 ├── media
 │   ├── fig1.jpeg
 │   └── fig2.png
-└── slides.pmd
+└── slides.md
 ```
 
 The important files in this folder include:
 
 - [index.md](#the-indexmd-file)
 - [info.md](#the-infomd-file)
-- [slides pmd file](#the-slides-pmd-file)
+- [slides file](#the-slides-file)
 - [text, exercises and online resources files](#text-exercises-and-online-resources-files)
 - [the `media` folder](#the-media-folder)
 
@@ -73,17 +73,16 @@ Here, the `title` corresponds to the title of your chapter as shown in the modul
 
 Within a module, the `type` field defines the chapter type and assumes the following options:
 - `info`: for chapters containing general information material.
-- `slides`: for chapters defining presentations; see example [here](#the-slides-pmd-file).
+- `slides`: for chapters defining presentations; see example [here](#the-slides-file).
 - `reading`: for chapters containing focused reading material and on-line resources; see example [here](#exercises-and-online-resources-files).
 - `exercise`: for exercises; see example [here](#exercises-and-online-resources-files)
 
 Finally, the `order` field determines the sequence in which chapters appear on the module's overview page. Since the learning objectives are expected to come first, `order` should be set to `0` in the `info.md` file.
 
-## The slides pmd file
+## The slides file
 
 Similar to `info.md`, the slides file is also embedded as a chapter on the module's main page, using the `slides` chapter type, as described [above](#the-infomd-file).
 
-For now, they should be named with a different extension, `*.pmd`, to differentiate them from other chapter types.
 Like `info.md`, they also require an initial YAML heading, *e.g.*,
 ```markdown
 ---
@@ -92,7 +91,6 @@ type: slides
 order: 1
 ---
 
----
 <!-- .slide: data-state="title" -->
 
 ## Software Testing

--- a/module-dir-structure.md
+++ b/module-dir-structure.md
@@ -3,7 +3,7 @@
 To add a module, create a new folder inside the main `modules` directory
 named after your new module, *e.g.*, my-new-module.
 
-This new `modules/my-new-module/` directory with general structure:
+This new `modules/my-new-module/` directory has general structure:
 
 ```console
 my-new-module
@@ -17,7 +17,7 @@ my-new-module
 └── slides.pmd
 ```
 
-should contain the following files:
+and should contain the following files:
 
 - [index.md](#the-indexmd-file)
 - [info.md](#the-infomd-file)
@@ -26,6 +26,32 @@ should contain the following files:
 - [the `media` folder](#the-media-folder)
 
 ## The `index.md` file
+This file is entirely defined by a YAML header.
+An example `index.md` file is given below:
+
+```yaml
+---
+id: 1
+trl: medium
+category: Development
+title: Software Testing
+abstract: Local testing of your software and using Continuous Integration and Continuous Deployment (CI/CD)
+author: eScience Center
+thumbnail: "thumbnail-testing.jpg"
+visibility: visible
+---
+```
+The only important fields at this point are `category`, `title`, `thumbnail`, and `visibility`.
+
+The `category` field should be one of the categories defined in the `config.json` file which is located in the root directory. These are literally `sections` that group together modules within certain categories.
+
+The `title` field should be the title of the module; it will be shown on the main overview page.
+
+The `thumbnail` field should be the name of the thumbnail image, which should be placed in the `/modules/my-new-module/media` directory. This image shows up on the index page. You can add your own image to `/modules/my-new-module/media` and replace `thumbnail: "nlesc-dummy.png"` by `thumbnail: "my-module-thumbnail-image.png"`.
+
+The `visibility` field should be `visible` if you want to make this specific module visible in the final lesson rendering.  
+
+Finally, the `id`, `author`, `trl` (technical readiness level) and `abstract` properties are currently not used, but they are still here for legacy reasons.
 
 ## The `info.md` file
 
@@ -34,4 +60,6 @@ should contain the following files:
 ## Exercises and online resources files
 
 ## The `media` folder
+
+The `media` folder gathers any media used in your module, including presentation images, videos, and module's thumbnail image.
 

--- a/module-dir-structure.md
+++ b/module-dir-structure.md
@@ -99,6 +99,8 @@ order: 1
 ...
 ```
 
+> ``📝`` **Is your first slide not rendering correctly?** Make sure that your YAML heading is included and formatted according to the example above. Pay special attention to the proper placement of the `---` separator.
+
 Although the slides are written in Markdown, they are rendered using [Reveal.js](https://revealjs.com/), and for this reason, they follow a special format. This is discussed below.
 
 ### Slide types

--- a/module-dir-structure.md
+++ b/module-dir-structure.md
@@ -9,6 +9,7 @@ This new `modules/my-new-module/` directory has general structure:
 my-new-module
 ├── exercises.md
 ├── online_resources.md
+├── text.md
 ├── index.md
 ├── info.md
 ├── media
@@ -22,7 +23,7 @@ and should contain the following files:
 - [index.md](#the-indexmd-file)
 - [info.md](#the-infomd-file)
 - [slides pmd file](#the-slides-pmd-file)
-- [exercises and online resources files](#exercises-and-online-resources-files)
+- [text, exercises and online resources files](#text-exercises-and-online-resources-files)
 - [the `media` folder](#the-media-folder)
 
 ## The `index.md` file
@@ -70,7 +71,7 @@ order: 0
 
 Here, the `title` corresponds to the title of your chapter as shown in the module's overview page.
 
-Within a module, the `type` field defines the nature of the included chapter and assumes the following options:
+Within a module, the `type` field defines the chapter type and assumes the following options:
 - `info`: for chapters containing general information material.
 - `presentation`: for chapters defining presentations; see example [here](#the-slides-pmd-file).
 - `reading`: for chapters containing focused reading material and on-line resources; see example [here](#exercises-and-online-resources-files).
@@ -80,7 +81,109 @@ Finally, the `order` field determines the sequence in which chapters appear on t
 
 ## The slides pmd file
 
-## Exercises and online resources files
+Similar to `info.md`, the slides file is also embedded as a chapter on the module's main page, using the `presentation` chapter type, as described [above](#the-infomd-file).
+
+For now, they should be named with a different extension, `*.pmd`, to differentiate them from other chapter types.
+Like `info.md`, they also require an initial YAML heading, *e.g.*,
+```yaml
+---
+title: Software Testing
+type: slides
+order: 1
+---
+
+---
+<!-- .slide: data-state="title" -->
+
+## Software Testing
+
+---
+...
+```
+
+Although the slides are written in Markdown, they are rendered using [Reveal.js](https://revealjs.com/), and for this reason, they follow a special format. This is discussed below.
+
+### Slide types
+
+There are four different slide types:
+
+- Title slide, `data-state="title"`
+- Default slide, `data-state="standard"`
+- "About us", `data-state="about"`
+- "Let's stay in touch", `data-state="keepintouch"`
+
+A slide is fenced by three dashes, and (optionally) an HTML comment that indicates the slide type:
+
+```markdown
+
+---
+
+<!-- .slide: data-state="standard" -->
+
+```
+
+Always keep an empty line before and after the slide fence.
+
+The dashes indicate the slide borders; the are therefore only necessary between the slides, and not at the beginning or end of a presentation.
+
+### Slide content
+
+Slide content can be written in Markdown.
+
+To keep slides clean, use single images per slide.
+Styling in Reveal is not trivial, and it is best to keep it simple.
+
+Images can be embedded using either markdown syntax:
+
+```markdown
+![Mapping the Via Appia](media/viaappia.png)
+```
+
+Or, for more customisation, using HTML:
+
+```html
+<center>
+<img src="media/researchcycle.png" width="60%">
+</center>
+```
+
+### Slide notes
+
+Notes should be added at the bottom of the slide, as follows:
+
+```markdown
+
+Note:
+Here is the text of a note.
+
+---
+```
+
+where the `---` indicates the fence to the following slide.
+
+### Final slide
+
+The final slide should provide the contact information for the eScience Center.
+This is not hardcoded into the slides, so it should be provided explicitly.
+
+The code for the final slide is as follows:
+
+```markdown
+
+---
+
+<!-- .slide: data-state="keepintouch" -->
+
+
+www.esciencecenter.nl
+
+info@esciencecenter.nl
+
+020 - 460 47 70
+
+```
+
+## Text, exercises and online resources files
 
 ## The `media` folder
 

--- a/module-dir-structure.md
+++ b/module-dir-structure.md
@@ -3,7 +3,7 @@
 To add a module, create a new folder inside the main `modules` directory
 named after your new module, *e.g.*, `my-new-module`.
 
-This new `modules/my-new-module/` folder has the general structure:
+This new `modules/my-new-module/` folder should be organized according to the following general structure:
 
 ```console
 my-new-module
@@ -18,7 +18,7 @@ my-new-module
 └── slides.pmd
 ```
 
-that should contain the following files:
+The important files in this folder include:
 
 - [index.md](#the-indexmd-file)
 - [info.md](#the-infomd-file)
@@ -27,12 +27,12 @@ that should contain the following files:
 - [the `media` folder](#the-media-folder)
 
 ## The `index.md` file
-This file is entirely defined by a YAML header.
+This file represents the core of your module and is entirely defined by a YAML header.
 An example `index.md` file is given below:
 
 ```yaml
 ---
-id: 1
+id: 0
 trl: medium
 category: Development
 title: Software Testing
@@ -42,17 +42,17 @@ thumbnail: "thumbnail-testing.jpg"
 visibility: visible
 ---
 ```
-The only important fields at this point are `category`, `title`, `thumbnail`, and `visibility`.
+The `category` field should match one of the categories defined in the `config.json` file (`"categoryOrder"` field), which is located in the content's repo root directory; see, *e.g.*, [here](https://github.com/esciencecenter-digital-skills/NEBULA-content-template/blob/main/config.json). These categories are essentially sections that group together modules within specific thematic areas.
 
-The `category` field should be one of the categories defined in the `config.json` file which is located in the root directory. These are literally `sections` that group together modules within certain categories.
+The `id` field is used to determine the position of the current module within the specified `category`.
 
 The `title` field should be the title of the module; it will be shown on the main overview page.
 
 The `thumbnail` field should be the name of the thumbnail image, which should be placed in the `/modules/my-new-module/media` directory. This image shows up on the index page. You can add your own image to `/modules/my-new-module/media` and replace `thumbnail: "nlesc-dummy.png"` by `thumbnail: "my-module-thumbnail-image.png"`.
 
-The `visibility` field should be `visible` if you want to make this specific module visible in the final lesson rendering.  
+The `visibility` field should be set to `visible` if you want to make this specific module visible in the final lesson rendering. Otherwise, set it to, *e.g.*, `not visible`.
 
-Finally, the `id`, `author`, `trl` (technical readiness level) and `abstract` properties are currently not used, but they are still here for legacy reasons.
+Finally, the `author`, `trl` (technical readiness level) and `abstract` fields do not influence the final module rendering, but they can be very useful for internal control and for developers.
 
 ## The `info.md` file
 This file defines the learning objectives of your module and is generally the first chapter to appear on the main module's overview page. An example `info.md` file is shown below:

--- a/module-dir-structure.md
+++ b/module-dir-structure.md
@@ -54,6 +54,29 @@ The `visibility` field should be `visible` if you want to make this specific mod
 Finally, the `id`, `author`, `trl` (technical readiness level) and `abstract` properties are currently not used, but they are still here for legacy reasons.
 
 ## The `info.md` file
+This file defines the learning objectives of your module and is generally the first chapter to appear on the main module's overview page. An example `info.md` file is shown below:
+```yaml
+---
+title: Learning objectives
+type: info
+order: 0
+---
+
+- Appreciate the importance of testing software
+- Understand the various benefits of testing
+- Understand the types of tests and what info they convey
+- Get familiar with the idea of continuous integration and its importance
+```
+
+Here, the `title` corresponds to the title of your chapter as shown in the module's overview page.
+
+Within a module, the `type` field defines the nature of the included chapter and assumes the following options:
+- `info`: for chapters containing general information material.
+- `presentation`: for chapters defining presentations; see example [here](#the-slides-pmd-file).
+- `reading`: for chapters containing focused reading material and on-line resources; see example [here](#exercises-and-online-resources-files).
+- `exercise`: for exercises; see example [here](#exercises-and-online-resources-files)
+
+Finally, the `order` field determines the sequence in which chapters appear on the module's overview page. Since the learning objectives are expected to come first, `order` should be set to `0` in the `info.md` file.
 
 ## The slides pmd file
 

--- a/module-dir-structure.md
+++ b/module-dir-structure.md
@@ -1,9 +1,9 @@
 # Directory structure and content tags
 
 To add a module, create a new folder inside the main `modules` directory
-named after your new module, *e.g.*, my-new-module.
+named after your new module, *e.g.*, `my-new-module`.
 
-This new `modules/my-new-module/` directory has general structure:
+This new `modules/my-new-module/` folder has the general structure:
 
 ```console
 my-new-module
@@ -18,7 +18,7 @@ my-new-module
 └── slides.pmd
 ```
 
-and should contain the following files:
+that should contain the following files:
 
 - [index.md](#the-indexmd-file)
 - [info.md](#the-infomd-file)
@@ -73,7 +73,7 @@ Here, the `title` corresponds to the title of your chapter as shown in the modul
 
 Within a module, the `type` field defines the chapter type and assumes the following options:
 - `info`: for chapters containing general information material.
-- `presentation`: for chapters defining presentations; see example [here](#the-slides-pmd-file).
+- `slides`: for chapters defining presentations; see example [here](#the-slides-pmd-file).
 - `reading`: for chapters containing focused reading material and on-line resources; see example [here](#exercises-and-online-resources-files).
 - `exercise`: for exercises; see example [here](#exercises-and-online-resources-files)
 
@@ -81,7 +81,7 @@ Finally, the `order` field determines the sequence in which chapters appear on t
 
 ## The slides pmd file
 
-Similar to `info.md`, the slides file is also embedded as a chapter on the module's main page, using the `presentation` chapter type, as described [above](#the-infomd-file).
+Similar to `info.md`, the slides file is also embedded as a chapter on the module's main page, using the `slides` chapter type, as described [above](#the-infomd-file).
 
 For now, they should be named with a different extension, `*.pmd`, to differentiate them from other chapter types.
 Like `info.md`, they also require an initial YAML heading, *e.g.*,
@@ -199,8 +199,7 @@ order: 2
 Software testing is the process of evaluating and verifying that software meet specified requirements...
 ```
 where it uses the `reading` chapter type as described [above](#the-infomd-file).
-
-In turn, an `exercise.md` chapter can assume the following format
+In turn, an `exercise.md` chapter can assume the following format:
 
 ```markdown
 ---
@@ -210,6 +209,7 @@ order: 3
 ---
 
 # Exercise 1
+
 ....
 ```
 
@@ -225,6 +225,7 @@ order: 4
 # Reading material
 
 ## Testing
+
 Follow the links below to read more about software testing.
 ....
 ```

--- a/module-dir-structure.md
+++ b/module-dir-structure.md
@@ -56,7 +56,7 @@ Finally, the `id`, `author`, `trl` (technical readiness level) and `abstract` pr
 
 ## The `info.md` file
 This file defines the learning objectives of your module and is generally the first chapter to appear on the main module's overview page. An example `info.md` file is shown below:
-```yaml
+```markdown
 ---
 title: Learning objectives
 type: info
@@ -85,7 +85,7 @@ Similar to `info.md`, the slides file is also embedded as a chapter on the modul
 
 For now, they should be named with a different extension, `*.pmd`, to differentiate them from other chapter types.
 Like `info.md`, they also require an initial YAML heading, *e.g.*,
-```yaml
+```markdown
 ---
 title: Software Testing
 type: slides
@@ -184,6 +184,50 @@ info@esciencecenter.nl
 ```
 
 ## Text, exercises and online resources files
+These chapters are defined by simply Markdown `*.md` files with an initial YAML heading.
+
+An example `text.md` file is shown below:
+```markdown
+---
+title: Software Testing
+type: reading
+order: 2
+---
+
+## Software Testing (5 minutes)
+
+Software testing is the process of evaluating and verifying that software meet specified requirements...
+```
+where it uses the `reading` chapter type as described [above](#the-infomd-file).
+
+In turn, an `exercise.md` chapter can assume the following format
+
+```markdown
+---
+title: Exercise 1
+type: exercise
+order: 3
+---
+
+# Exercise 1
+....
+```
+
+while an online resources file is given by:
+
+```markdown
+---
+title: Reading material
+type: reading
+order: 4
+---
+
+# Reading material
+
+## Testing
+Follow the links below to read more about software testing.
+....
+```
 
 ## The `media` folder
 


### PR DESCRIPTION
This PR adds info to `module-dir-structure.md`, giving general guidelines on how to add new modules to RSS or any other custom-made lesson.

- Closes https://github.com/esciencecenter-digital-skills/NEBULA-docs/issues/5
- Closes https://github.com/esciencecenter-digital-skills/NEBULA-docs/issues/1
- Closes https://github.com/esciencecenter-digital-skills/NEBULA-docs/issues/4